### PR TITLE
Add watch & debug tasks, add resource cleanup

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,8 +12,10 @@
     ],
     "scripts": {
         "build": "napi build --platform --release",
+        "debug": "napi build --platform",
         "prepare": "node scripts/prepare-platforms.js",
-        "test": "cargo test"
+        "test": "cargo test",
+        "watch": "nodemon --ext rs,js test.js --exec \"yarn debug && node test.js\""
     },
     "napi": {
         "name": "dist/core",
@@ -35,7 +37,8 @@
     },
     "devDependencies": {
         "@napi-rs/cli": "^2.13.2",
-        "@napi-rs/triples": "^1.1.0"
+        "@napi-rs/triples": "^1.1.0",
+        "nodemon": "^2.0.20"
     },
     "publishConfig": {
         "registry": "https://registry.npmjs.org/",

--- a/packages/core/src/callbacks.rs
+++ b/packages/core/src/callbacks.rs
@@ -6,7 +6,7 @@ pub struct CallbackStore {
 }
 
 pub struct CallbackRef {
-    reference: Ref<()>,
+    pub reference: Ref<()>,
 }
 
 impl CallbackRef {

--- a/packages/core/src/callbacks.rs
+++ b/packages/core/src/callbacks.rs
@@ -6,21 +6,29 @@ pub struct CallbackStore {
 }
 
 pub struct CallbackRef {
+    env: Env,
     pub reference: Ref<()>,
 }
 
 impl CallbackRef {
-    pub fn new(env: &Env, callback: JsFunction) -> napi::Result<CallbackRef> {
+    pub fn new(env: Env, callback: JsFunction) -> napi::Result<CallbackRef> {
         let reference = env.create_reference::<JsFunction>(callback)?;
-        Ok(CallbackRef { reference })
+        Ok(CallbackRef { reference, env })
     }
     pub fn call<V: NapiValue>(
         &self,
-        env: &Env,
         this: Option<&JsObject>,
         args: &[V],
     ) -> napi::Result<JsUnknown> {
-        let value: JsFunction = env.get_reference_value(&self.reference)?;
+        let value: JsFunction = self.env.get_reference_value(&self.reference)?;
         value.call(this, args)
+    }
+}
+
+impl Drop for CallbackRef {
+    fn drop(&mut self) {
+        if let Err(e) = self.reference.unref(self.env) {
+            eprintln!("Error unrefing callback: {}", e);
+        }
     }
 }

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -29,7 +29,7 @@ impl VoiceCore {
             old_ref.reference.unref(env)?;
         }
 
-        self.callbacks.device_change = Some(CallbackRef::new(&env, callback)?);
+        self.callbacks.device_change = Some(CallbackRef::new(env, callback)?);
         Ok(())
     }
     #[napi]
@@ -42,7 +42,7 @@ impl VoiceCore {
             old_ref.reference.unref(env)?;
         }
 
-        self.callbacks.volume_change = Some(CallbackRef::new(&env, callback)?);
+        self.callbacks.volume_change = Some(CallbackRef::new(env, callback)?);
         Ok(())
     }
     #[napi]
@@ -51,7 +51,6 @@ impl VoiceCore {
             let format = env.create_string("Volume was set to %o, also six = %o")?;
             let six = env.create_int32(6)?;
             reference.call(
-                &env,
                 None,
                 &[
                     format.into_unknown(),

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -25,6 +25,10 @@ impl VoiceCore {
         env: Env,
         callback: JsFunction,
     ) -> napi::Result<()> {
+        if let Some(old_ref) = &mut self.callbacks.device_change {
+            old_ref.reference.unref(env)?;
+        }
+
         self.callbacks.device_change = Some(CallbackRef::new(&env, callback)?);
         Ok(())
     }
@@ -34,6 +38,10 @@ impl VoiceCore {
         env: Env,
         callback: JsFunction,
     ) -> napi::Result<()> {
+        if let Some(old_ref) = &mut self.callbacks.volume_change {
+            old_ref.reference.unref(env)?;
+        }
+
         self.callbacks.volume_change = Some(CallbackRef::new(&env, callback)?);
         Ok(())
     }

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -25,10 +25,6 @@ impl VoiceCore {
         env: Env,
         callback: JsFunction,
     ) -> napi::Result<()> {
-        if let Some(old_ref) = &mut self.callbacks.device_change {
-            old_ref.reference.unref(env)?;
-        }
-
         self.callbacks.device_change = Some(CallbackRef::new(env, callback)?);
         Ok(())
     }

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -34,10 +34,6 @@ impl VoiceCore {
         env: Env,
         callback: JsFunction,
     ) -> napi::Result<()> {
-        if let Some(old_ref) = &mut self.callbacks.volume_change {
-            old_ref.reference.unref(env)?;
-        }
-
         self.callbacks.volume_change = Some(CallbackRef::new(env, callback)?);
         Ok(())
     }

--- a/packages/core/test.js
+++ b/packages/core/test.js
@@ -1,0 +1,6 @@
+const VoiceEngine = require(".");
+
+const core = VoiceEngine.start();
+
+core.setVolumeChangeCallback((...args) => console.log(...args));
+core.setLocalVolume(20);


### PR DESCRIPTION
debug builds are wayyyy faster than release and the watch tasks just always recompiles on change. I also added some clean up code for references

~~Another problem is that references aren't properly cleaned up when the voice engine object is garbage collected~~